### PR TITLE
Revert "chore: remove unused dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "dependencies": {
         "@slack/bolt": "^3.11.3",
         "dotenv": "^16.0.0",
+        "pg": "^8.7.3",
+        "pg-hstore": "^2.3.4",
         "semver": "^7.5.2",
         "sequelize": "^6.29.0"
     }


### PR DESCRIPTION
This reverts commit 443a7ee942846cb600eb0bf5cea7631c2189dda7.

Looks like these are needed actually: https://github.com/electron/hippo/actions/runs/6854117464/job/18636380216