### PR TITLE
fix: use include-hidden-files with actions/upload-artifact

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,3 +33,4 @@ jobs:
       with:
         name: cache
         path: .cache
+        include-hidden-files: true


### PR DESCRIPTION
v4.4.0 of the action was [a breaking change](https://github.com/actions/upload-artifact/issues/602) that stopped uploading hidden files by default.